### PR TITLE
Select all command

### DIFF
--- a/chrome/content/db/firemacs.yml
+++ b/chrome/content/db/firemacs.yml
@@ -551,3 +551,8 @@ keyx: C-n
 body: this._sfun.NextCompletion(e);
 desc: moves to the next line
 type: 
+-
+name: SelectAll
+case: Common
+keyx: C-xh
+body: goDoCommand('cmd_selectAll')


### PR DESCRIPTION
Hi

I've tried to add a select all command (C-x h) from emacs to Firemacs. I think it's correct.

I couldn't build Firemacs, so I'm afraid I couldn't check it. I think `make.hs` depends on something I haven't got that isn't mentioned in the readme:

```
wilfred@alto ~/s/F/c/c/db> runghc make.hs

make.hs:6:7:
    Could not find module `Text.Parsec.String':
      Use -v to see a list of the files searched for.
```

Many thanks.
