### PR TITLE
FF 4 compatibility

### DIFF
--- a/chrome.manifest
+++ b/chrome.manifest
@@ -1,3 +1,4 @@
+overlay	chrome://browser/content/browser.xul	chrome://firemacs/content/firemacs.xul
 overlay	chrome://browser/content/browser.xul	chrome://firemacs/content/statusbar.xul
 content	firemacs	jar:chrome/firemacs.jar!/content/
 skin	firemacs	classic/1.0	jar:chrome/firemacs.jar!/skin/

--- a/install.rdf
+++ b/install.rdf
@@ -5,13 +5,13 @@
 
   <Description about="urn:mozilla:install-manifest">
     <em:id>{e98b7313-167d-48c6-89be-bc514d6de8d9}</em:id>
-    <em:version>3.8</em:version>
+    <em:version>3.801</em:version>
     <em:type>2</em:type>
     <em:targetApplication>
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>1.5</em:minVersion>
-        <em:maxVersion>3.6.*</em:maxVersion>
+        <em:maxVersion>4.0.*</em:maxVersion>
       </Description>
     </em:targetApplication>
     <em:name>Firemacs</em:name>


### PR DESCRIPTION
I made a couple of changes to make firemacs work with FF4. I basically just hacked around until it worked, but in the end I think it was just explicitly adding the firemacs.xul overlay to chrome.manifest that fixed it. I don't know much about FF extensions but I'm guessing firemacs.xul was getting loaded automatically in FF3 (based on addon name match?) and this isn't happening in FF4. 

The changes are so small that it might be quicker for you to apply them manually than it would be to pull them, but here they are anyway. 

Cheers
Diego
