### PR TITLE
FF4 betas xul registration

### DIFF
--- a/chrome.manifest
+++ b/chrome.manifest
@@ -1,4 +1,4 @@
-overlay	chrome://browser/content/browser.xul	chrome://firemacs/content/firemacs.xul application={ec8030f7-c20a-464f-9b0e-13a3a9e97384} appversion>=4.0
+overlay	chrome://browser/content/browser.xul	chrome://firemacs/content/firemacs.xul application={ec8030f7-c20a-464f-9b0e-13a3a9e97384} appversion>=4.0.* appversion>=4.0b0.*
 overlay	chrome://browser/content/browser.xul	chrome://firemacs/content/statusbar.xul
 content	firemacs	jar:chrome/firemacs.jar!/content/
 skin	firemacs	classic/1.0	jar:chrome/firemacs.jar!/skin/


### PR DESCRIPTION
It seems that FF's version sorting works in a weird way to cater for pre-release versions. From https://developer.mozilla.org/en/Toolkit_version_format:
"A string-part that exists is always less-then a nonexisting string-part (1.6a is less than 1.6)."

This means with the new appversion flag in chrome.manifest the xul won't get registered for the FF4 betas, since, for example, 4.0b13pre < 4.0.*.

This commit adds a second appversion flag to allow the xul to be registered in the betas. In theory since 4.0b < 4.0 there's no need for the two, but having no FF4.0 to try it against I left the 4.0.\* appversion flag there as it was, since according to https://developer.mozilla.org/en/chrome_registration "Multiple appversion flags may be included on a single line, in which case the line is applied if any of the flags match". That way we can be sure that it'll still work once FF4.0 is released. 

Cheers
Diego 
